### PR TITLE
added require for safe transfer WETH

### DIFF
--- a/src/ERC721TokenVault.sol
+++ b/src/ERC721TokenVault.sol
@@ -401,7 +401,10 @@ contract TokenVault is ERC20Upgradeable, ERC721HolderUpgradeable {
             // the auction is not impeded and the recipient still
             // can claim ETH via the WETH contract (similar to escrow).
             IWETH(weth).deposit{value: value}();
-            IWETH(weth).transfer(to, value);
+            require(
+                IWETH(weth).transfer(to, value),
+                "WETH: Transfer Transfer not successful"
+            );
             // At this point, the recipient can unwrap WETH.
         }
     }


### PR DESCRIPTION
Hello, there was no check in the _sendETHOrWETH method that the WETH transfer was successful. It is necessary because the transfer ERC20 method can return false